### PR TITLE
Fix: resolve TypeError in layout.tsx due to async headers

### DIFF
--- a/modal-login/app/layout.tsx
+++ b/modal-login/app/layout.tsx
@@ -13,16 +13,17 @@ export const metadata: Metadata = {
   description: "Modal sign in for Gensyn Testnet",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Persist state across pages
-  // https://accountkit.alchemy.com/react/ssr#persisting-the-account-state
+  // Wait a headers
+  const headerData = await headers();
+
   const initialState = cookieToInitialState(
     config,
-    headers().get("cookie") ?? undefined,
+    headerData.get("cookie") ?? undefined,
   );
 
   return (


### PR DESCRIPTION
Fixes a build failure in layout.tsx due to missing `await` on async `headers()` object.
Error:
Property 'get' does not exist on type 'Promise<ReadonlyHeaders>'

```
./app/layout.tsx:25:15
Type error: Property 'get' does not exist on type 'Promise<ReadonlyHeaders>'.
  23 |   const initialState = cookieToInitialState(
  24 |     config,
> 25 |     headers().get("cookie") ?? undefined,
     |               ^
  26 |   );
  27 |
  28 |   return (
Next.js build worker exited with code: 1 and signal: null
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```